### PR TITLE
build x64 binaries for windows and make mac builds work again

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -60,7 +60,7 @@ windows:
     image: build-system/unity-extra-windows-10:v0.6-921129
     flavor: b1.small
   commands:
-    - cmake -S . -DBUILD_SHARED_LIBS=OFF
+    - cmake -S . -DBUILD_SHARED_LIBS=OFF -DCMAKE_GENERATOR_PLATFORM=x64
     - YASM-VERSION-GEN.bat
     - |
       "%ProgramFiles(x86)%\MSBuild\14.0\bin\msbuild.exe" yasm.sln /p:Configuration=Release /t:yasm
@@ -72,11 +72,11 @@ windows:
     - cp Artistic.txt build
     - cp libyasm/bitvect.c build
     - cp libyasm/bitvect.h build
-    - cd build && 7z a yasm-win-x86.7z *
+    - cd build && 7z a yasm-win-x64.7z *
   artifacts:
     build:
       paths:
-        - build/yasm-win-x86.7z
+        - build/yasm-win-x64.7z
     test-results:
       paths:
         - test-suite.log

--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -32,19 +32,28 @@ macos-x64:
     image: build-system/unity-extra-macos-10.13:v0.3.6-620952
     flavor: b1.small
   commands:
-    - ./autogen.sh
-    - make
-    - make check 
-    - mkdir -p build
-    - cp ./yasm ./build/
-    - cp COPYING ./build/LICENSE
-    - cp BSD.txt ./build/
-    # bitvect is under the Artistic license, not BSD
-    - cp Artistic.txt ./build/
-    - cp libyasm/bitvect.c ./build/
-    - cp libyasm/bitvect.h ./build/
-    - brew install p7zip
-    - cd build && 7z a yasm-mac-x64.7z *
+    - |
+      set -euo pipefail
+      ./autogen.sh
+      make
+      make check 
+      mkdir -p build
+      cp ./yasm ./build/
+      cp COPYING ./build/LICENSE
+      cp BSD.txt ./build/
+      # bitvect is under the Artistic license, not BSD
+      cp Artistic.txt ./build/
+      cp libyasm/bitvect.c ./build/
+      cp libyasm/bitvect.h ./build/
+      wget https://public-stevedore.unity3d.com/r/public/7za-mac-x64/95bf0d3a17b5_1887c56255e2db1134e118f27abe1ec62a2aca092ec9f72600c80659da17ca11.zip
+      actual_hash=$(shasum -a 256 95bf0d3a17b5_1887c56255e2db1134e118f27abe1ec62a2aca092ec9f72600c80659da17ca11.zip | cut -f1 -d' ')
+      if [ "$actual_hash" != 1887c56255e2db1134e118f27abe1ec62a2aca092ec9f72600c80659da17ca11 ] ; then
+        echo "Error: 7za package hash does not match"
+        exit 1
+      fi
+      unzip -p 95bf0d3a17b5_1887c56255e2db1134e118f27abe1ec62a2aca092ec9f72600c80659da17ca11.zip > 7za
+      chmod +x 7za
+      cd build && ../7za a yasm-mac-x64.7z *
   artifacts:
     build:
       paths:

--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -2,7 +2,7 @@ linux:
   name: "Linux"
   agent:
     type: Unity::VM
-    image: build-system/unity-extra-ubuntu-18.04:latest
+    image: build-system/unity-extra-ubuntu-18.04:henrikp-v0.4.1-617534
     flavor: b1.small
   commands:
     - ./autogen.sh
@@ -29,7 +29,7 @@ macos-x64:
   name: "macOS (x64)"
   agent:
     type: Unity::VM::osx
-    image: build-system/unity-extra-macos-10.13:latest
+    image: build-system/unity-extra-macos-10.13:v0.3.6-620952
     flavor: b1.small
   commands:
     - ./autogen.sh
@@ -57,7 +57,7 @@ windows:
   name: "Windows"
   agent:
     type: Unity::VM
-    image: build-system/unity-extra-windows-10:latest
+    image: build-system/unity-extra-windows-10:v0.6-921129
     flavor: b1.small
   commands:
     - cmake -S . -DBUILD_SHARED_LIBS=OFF


### PR DESCRIPTION
* We should build x64 binaries for windows.
* Mac builds stopped working due to homebrew no longer supporting macos 10.13.
* Use specific CI images instead of "latest" (which has fallen out of favour).